### PR TITLE
Fix/multiple requests same

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         simulator:
           - name: "iPhone 16"
-            os: "18.0"
+            os: "18.5"
     
     steps:
     - name: Checkout code

--- a/Sources/DownloadKitCore/Cache/ResourceCachable.swift
+++ b/Sources/DownloadKitCore/Cache/ResourceCachable.swift
@@ -16,16 +16,25 @@ public protocol ResourceCachable: Sendable, ResourceRetrievable {
     /// Mirror policy.
     var mirrorPolicy: MirrorPolicy { get }
     
+    // MARK: - Methods without any side effects.
+    
     /// Returns downloadable items, that are not stored locally.
     /// - Parameters:
     ///   - resources: resources we're interested in.
     ///   - options: request options.
     func requestDownloads(resources: [ResourceFile], options: RequestOptions) async -> [DownloadRequest]
     
-    /// Returns download request for certain downloadable, if cache created it.
+    /// Returns download requests for certain downloadable, if cache is processing it.
     /// - Parameter downloadable: item that we need request for.
     /// - Returns: original request object.
-    func downloadRequest(for downloadable: Downloadable) async -> DownloadRequest?
+    func downloadRequests(for downloadable: Downloadable) async -> [DownloadRequest]
+    
+    // MARK: - Methods that perform actions
+    
+    /// Download request will be processed.
+    /// - Parameters:
+    ///   - request: download request returned from requestDownloads method.
+    func processDownload(_ request: DownloadRequest) async
     
     /// Called after the download finishes successfully.
     /// - Parameters:

--- a/Sources/DownloadKitCore/Core/DownloadTypes.swift
+++ b/Sources/DownloadKitCore/Core/DownloadTypes.swift
@@ -60,9 +60,3 @@ public protocol ResourceImageRetrievable : Sendable {
 public protocol ResourceRetrievable : ResourceFileRetrievable, ResourceDataRetrievable, ResourceImageRetrievable {
     
 }
-
-public extension DownloadRequest {
-    var resourceId : String {
-        return resource.id
-    }
-}

--- a/Sources/DownloadKitRealm/RealmCacheManager.swift
+++ b/Sources/DownloadKitRealm/RealmCacheManager.swift
@@ -171,7 +171,7 @@ public final class RealmCacheManager<L: Object>: ResourceCachable where L: Local
     }
     
     public func processDownload(_ request: DownloadRequest) async {
-        log.info("Download is will be processed \(request.id)")
+        log.info("Download will be processed \(request.id)")
         
         let identifier = request.id
         await requestMap.add(request, for: identifier)

--- a/Sources/DownloadKitRealm/RealmLocalCacheManager.swift
+++ b/Sources/DownloadKitRealm/RealmLocalCacheManager.swift
@@ -10,6 +10,7 @@ import DownloadKitCore
 import RealmSwift
 import os.log
 
+
 public final class RealmLocalCacheManager<L: Object>: ResourceFileRetrievable, Sendable where L: LocalResourceFile {
     public let log = Logger(subsystem: "org.blubblub.downloadkit.realm.cache.local", category: "Cache")
     
@@ -47,7 +48,6 @@ public final class RealmLocalCacheManager<L: Object>: ResourceFileRetrievable, S
         self.shouldDownload = shouldDownload
     }
     
-    
     /// Returns fileURL to resource id, if available.
     /// - Parameter resourceId: resource id to fetch URL for
     /// - Returns: URL if exists.
@@ -78,7 +78,6 @@ public final class RealmLocalCacheManager<L: Object>: ResourceFileRetrievable, S
         
         return nil
     }
-    
     
     private func replaceSandboxURL(in url: URL, for storage: StoragePriority) -> URL {
         let baseURL: URL

--- a/Tests/DownloadKitTests/ResourceManagerIntegrationTests.swift
+++ b/Tests/DownloadKitTests/ResourceManagerIntegrationTests.swift
@@ -476,6 +476,8 @@ class ResourceManagerIntegrationTests: XCTestCase {
         let requests = await manager.request(resources: resources)
         print("Created \(requests.count) download requests")
         
+        XCTAssertEqual(requests.count, resourceCount, "Request count should match resource count")
+        
         // Check metrics after request
         let afterRequestMetrics = manager.metrics
         let afterRequestMetricsDescription = await afterRequestMetrics.description
@@ -499,6 +501,7 @@ class ResourceManagerIntegrationTests: XCTestCase {
                     } else {
                         await failureCount.increment()
                     }
+                    
                     metricsExpectation.fulfill()
                 }
             }
@@ -508,7 +511,7 @@ class ResourceManagerIntegrationTests: XCTestCase {
         await manager.process(requests: requests)
         
         // Wait for downloads to complete
-        await fulfillment(of: [metricsExpectation], timeout: 300)
+        await fulfillment(of: [metricsExpectation], timeout: 3000)
         
         let completedCount = await completionCount.value
         let failedCount = await failureCount.value

--- a/Tests/DownloadKitTests/ResourceManagerIntegrationTests.swift
+++ b/Tests/DownloadKitTests/ResourceManagerIntegrationTests.swift
@@ -511,7 +511,7 @@ class ResourceManagerIntegrationTests: XCTestCase {
         await manager.process(requests: requests)
         
         // Wait for downloads to complete
-        await fulfillment(of: [metricsExpectation], timeout: 3000)
+        await fulfillment(of: [metricsExpectation], timeout: 300)
         
         let completedCount = await completionCount.value
         let failedCount = await failureCount.value

--- a/Tests/DownloadKitTests/ResourceManagerTests.swift
+++ b/Tests/DownloadKitTests/ResourceManagerTests.swift
@@ -420,7 +420,6 @@ class ResourceManagerTests: XCTestCase {
         // Then - verify all transfers are created successfully
         XCTAssertEqual(requests.count, amount, "Should create \(amount) requests")
         
-        
         // Transfer them all concurrently
         await withTaskGroup(of: Void.self) { group in
             for (index, request) in requests.enumerated() {


### PR DESCRIPTION
Fixes issue with multiple requests into DownloadKit for same asset. If `DownloadRequest` was awaited, only one of them would complete. This ensures all requests are tracked and all of them are completed. Callbacks are sent once for successful download and resource completions are also called once. However all `DownloadRequest` objects that were sent to `process` are now properly completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support multiple download requests per resource and an explicit processing step for downloads.

- Bug Fixes
  - More predictable start/processing flow and improved progress reporting.
  - More reliable cancellation and error handling across simultaneous requests.
  - Reduced duplicate work when multiple requests target the same content.

- Tests
  - Added concurrency test for simultaneous downloads and assertions for request counts and per-resource metrics.

- Chores
  - Updated iOS simulator OS version in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->