### PR TITLE
[CU-869b9b44m] FIX: If resource's file on disk is deleted, it's never…

### DIFF
--- a/Sources/DownloadKitRealm/RealmLocalCacheManager.swift
+++ b/Sources/DownloadKitRealm/RealmLocalCacheManager.swift
@@ -250,7 +250,7 @@ public final class RealmLocalCacheManager<L: Object>: ResourceFileRetrievable, S
             }
             
             // Check if resource file url points to a file that exists
-            guard file.fileExists(atPath: resource.fileURL.path) else {
+            guard let resolvedURL = fileURL(for: resource.id), file.fileExists(atPath: resolvedURL.path) else {
                 return true
             }
             

--- a/Sources/DownloadKitRealm/RealmLocalCacheManager.swift
+++ b/Sources/DownloadKitRealm/RealmLocalCacheManager.swift
@@ -17,12 +17,10 @@ public final class RealmLocalCacheManager<L: Object>: ResourceFileRetrievable, S
     /// Target Realm to update
     public let configuration: Realm.Configuration
     
-    public let resourceSubdirectory : String
-    public let excludeFilesFromBackup : Bool
+    public let resourceSubdirectory: String
+    public let excludeFilesFromBackup: Bool
     
-    public let shouldDownload: (@Sendable (ResourceFile) -> Bool)?
-    
-    private var file : FileManager {
+    private var file: FileManager {
         FileManager.default
     }
 
@@ -40,12 +38,10 @@ public final class RealmLocalCacheManager<L: Object>: ResourceFileRetrievable, S
     
     public init(configuration: Realm.Configuration,
                 resourceSubdirectory: String = "resources/",
-                excludeFilesFromBackup: Bool = true,
-                shouldDownload: (@Sendable (ResourceFile) -> Bool)? = nil) {
+                excludeFilesFromBackup: Bool = true) {
         self.configuration = configuration
         self.resourceSubdirectory = resourceSubdirectory
         self.excludeFilesFromBackup = excludeFilesFromBackup
-        self.shouldDownload = shouldDownload
     }
     
     /// Returns fileURL to resource id, if available.
@@ -248,12 +244,13 @@ public final class RealmLocalCacheManager<L: Object>: ResourceFileRetrievable, S
         // Get resources that need to be downloaded.
         let downloadableResources = resources.filter { item in
             
-            if let shouldDownload = shouldDownload {
-                return shouldDownload(item)
-            }
-            
             // No local resource, let's download.
             guard let resource = realm.object(ofType: L.self, forPrimaryKey: item.id) else {
+                return true
+            }
+            
+            // Check if resource file url points to a file that exists
+            guard file.fileExists(atPath: resource.fileURL.path) else {
                 return true
             }
             


### PR DESCRIPTION
* Removed the `shouldDownload` closure property and its parameter from the `RealmLocalCacheManager` initializer, making the download criteria internal to the class.
* Updated the resource filtering logic to directly check for the existence of the local file and compare modification dates, rather than deferring to an external `shouldDownload` function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Initialization simplified by removing a manual download predicate; resource syncing is now automatic based on local file presence and remote timestamps.
  * Public initializer updated to reflect this change; no added public APIs.

* **Tests**
  * Added tests to ensure resources are re-downloaded when their local files are deleted, validating revalidation and sync behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->